### PR TITLE
Improved buf_t testing script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,6 @@ script:
 notifications:
   email:
     recipients:
-      - regrant@sandia.gov
+      - timo.schneider@intel.com
     on_success: [change]
     on_failure: [always] 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,6 @@ script:
 notifications:
   email:
     recipients:
-      - timo.schneider@intel.com
+      - regrant@sandia.gov
     on_success: [change]
     on_failure: [always] 

--- a/config/check_buf_alignment.m4
+++ b/config/check_buf_alignment.m4
@@ -3,7 +3,7 @@ dnl ptl_buf struct is required. This test checks for this alignment.
 
 AC_DEFUN([CHECK_BUF_ALIGNMENT], [
   saved_CPPFLAGS="$CPPFLAGS"
-  saved_LDLAGS="$CPPFLAGS"
+  saved_LDLAGS="$LDFLAGS"
   saved_LIBS="$LIBS"
   CPPFLAGS="$CPPFLAGS -I${srcdir}/src/ib/ -I${srcdir}/include/ -I${top_srcdir}/include ${ev_CPPFLAGS} ${ofed_CPPFLAGS} ${XPMEM_CPPFLAGS}" 
   LDFLAGS="$LDFLAGS ${ev_LDFLAGS} ${ofed_LDFLAGS} ${XPMEM_LDFLAGS}"

--- a/config/check_buf_alignment.m4
+++ b/config/check_buf_alignment.m4
@@ -3,8 +3,11 @@ dnl ptl_buf struct is required. This test checks for this alignment.
 
 AC_DEFUN([CHECK_BUF_ALIGNMENT], [
   saved_CPPFLAGS="$CPPFLAGS"
-  CPPFLAGS="$CPPFLAGS -I${srcdir}/src/ib/" 
-  CPPFLAGS="$CPPFLAGS -I${srcdir}/include/" 
+  saved_LDLAGS="$CPPFLAGS"
+  saved_LIBS="$LIBS"
+  CPPFLAGS="$CPPFLAGS -I${srcdir}/src/ib/ -I${srcdir}/include/ -I${top_srcdir}/include ${ev_CPPFLAGS} ${ofed_CPPFLAGS} ${XPMEM_CPPFLAGS}" 
+  LDFLAGS="$LDFLAGS ${ev_LDFLAGS} ${ofed_LDFLAGS} ${XPMEM_LDFLAGS}"
+  LIBS="$LIBS ${ev_LIBS} ${ofed_LIBS} ${XPMEM_LIBS}"
 AC_CACHE_CHECK([if buf is aligned right for triggered me],
   [ptl_cv_buf_aligned_for_trig_me],
   [AC_TRY_RUN([
@@ -47,5 +50,7 @@ else
   AC_MSG_ERROR(["fix the padding in buf_t or build without triggered me ops"])
 fi
 CPPFLAGS="$saved_CPPFLAGS"
+LDFLAGS="$saved_LDFLAGS"
+LIBS="$saved_LIBS"
 ])
 


### PR DESCRIPTION
We try to build a small portals program (that just uses the header file) thus, we should also use the same CPPFLAGS/LDFLAGS/etc. as Portals. Unfortunately the flags discovered by other tests are stored in intermediate vars during configure. This broke the travis build for OpenSHMEM, since it couldn't find the libev header file.