### PR TITLE
fix for PT index check

### DIFF
--- a/src/ib/ptl_tgt.c
+++ b/src/ib/ptl_tgt.c
@@ -459,7 +459,7 @@ static int tgt_start(buf_t *buf)
     }
 
     pt_index = le32_to_cpu(hdr->pt_index);
-    if (pt_index >= ni->limits.max_pt_index) {
+    if (pt_index > ni->limits.max_pt_index) {
         buf->ni_fail = PTL_NI_DROPPED;
         WARN();
         return STATE_TGT_DROP;


### PR DESCRIPTION
  only drop message if PT index is greater than max limit, not greater or equal