### PR TITLE
Fixing initialization of atomic/put and deadlock with 0-length data

### DIFF
--- a/src/ib/ptl_move.c
+++ b/src/ib/ptl_move.c
@@ -136,6 +136,7 @@ int _PtlPut(PPEGBL ptl_handle_md_t md_handle, ptl_size_t local_offset,
     buf->user_ptr = user_ptr;
     buf->put_offset = local_offset;
     buf->init_state = STATE_INIT_START;
+    buf->recv_buf = NULL;
 
     err = process_init(buf);; 
     if (unlikely(err))
@@ -222,6 +223,7 @@ int _PtlTriggeredPut(PPEGBL ptl_handle_md_t md_handle,
     buf->ct_threshold = threshold;
     buf->put_offset = local_offset;
     buf->init_state = STATE_INIT_START;
+    buf->recv_buf = NULL;
 
     post_ct(buf, ct);
 
@@ -550,6 +552,7 @@ int _PtlAtomic(PPEGBL ptl_handle_md_t md_handle, ptl_size_t local_offset,
     buf->user_ptr = user_ptr;
     buf->put_offset = local_offset;
     buf->init_state = STATE_INIT_START;
+    buf->recv_buf = NULL;
 
     err = process_init(buf); 
     if (unlikely(err)) 
@@ -641,6 +644,7 @@ int _PtlTriggeredAtomic(PPEGBL ptl_handle_md_t md_handle,
     buf->ct_threshold = threshold;
     buf->put_offset = local_offset;
     buf->init_state = STATE_INIT_START;
+    buf->recv_buf = NULL;
 
     post_ct(buf, ct);
 

--- a/src/ib/ptl_tgt.c
+++ b/src/ib/ptl_tgt.c
@@ -1041,6 +1041,7 @@ static int tgt_data(buf_t *buf)
         else if (buf->data_in && buf->data_in->data_fmt == DATA_FMT_NOKNEM)
             return STATE_TGT_DATA_IN;
 #endif
+        pthread_mutex_unlock(&ni->atomic_mutex);
         return STATE_TGT_COMM_EVENT;
     }
 }


### PR DESCRIPTION
c92e0e6 clears buf->recv_buf when creating a (triggered) put or atomic operation. Without this, the recv_buf is dirty, resulting in an invalid pointer passed to obj_put during the cleanup. 

e6f7925 fixes a deadlock occurring when an atomic/swap/fetch operation targets data with length 0. 
 