### PR TITLE
Allow a counter to be re-used after triggers have been canceled.

### DIFF
--- a/src/ib/ptl_ct.c
+++ b/src/ib/ptl_ct.c
@@ -269,6 +269,7 @@ int _PtlCTCancelTriggered(PPEGBL ptl_handle_ct_t ct_handle)
 
     ct->info.interrupt = 1;
     ct_check(ct);
+    ct->info.interrupt = 0;
 
     err = PTL_OK;
     ct_put(ct);


### PR DESCRIPTION
The trigger queue is drained in ct_check() after PtlCTCancelTriggered() is called. This patch simply re-enables the counter to allow new triggered events to be posted and processed.

The use case for this feature is a non-blocking, asynchronous collective operation that performs multiple phases. The collective is implemented using a tree of triggered operations. Once a communication phase has concluded, all triggers are reset and the collective starts anew.