### PR TITLE
- fix when using unordered matching and no match is found

### DIFF
--- a/src/ib/ptl_ct.c
+++ b/src/ib/ptl_ct.c
@@ -10,10 +10,15 @@
 #include "ptl_loc.h"
 #include "ptl_timer.h"
 
+
 /* TODO make these unnecessary by queuing deferred operations */
 void ct_check(ct_t *ct);
 static void post_trig_ct(struct buf *buf, ct_t *trig_ct);
 static void do_trig_ct_op(struct buf *buf);
+
+#ifdef WITH_TRIG_ME_OPS
+void do_trig_me_op(buf_t *buf, ct_t *ct);
+#endif
 
 /**
  * @brief Initialize a ct object once when created.
@@ -541,7 +546,7 @@ void ct_check(ct_t *ct)
             } else if ((ct->info.event.success + ct->info.event.failure) >=
                        buf->ct_threshold) {
                 ptl_info("ME operation triggered: %i on ct of: %i and threshold %i\n", 
-                         buf->op,ct->info.event.success,buf->ct_threshold);
+                         (int) buf->op, (int)ct->info.event.success, (int)buf->ct_threshold);
                 list_del(l);
                 atomic_dec(&ct->list_size);
 

--- a/src/ib/ptl_me.c
+++ b/src/ib/ptl_me.c
@@ -8,6 +8,7 @@
 #include "ptl_ct.h"
 
 #ifdef WITH_TRIG_ME_OPS
+void ct_check(ct_t *ct);
 static void post_trig_me(buf_t *buf, ct_t *me_ct);
 void do_trig_me_op(buf_t *buf, ct_t *ct);
 #endif

--- a/src/ib/ptl_tgt.c
+++ b/src/ib/ptl_tgt.c
@@ -651,6 +651,7 @@ static int tgt_get_match(buf_t *buf)
             }
             goto found_one;
         }
+        goto not_found;
     }
 #endif
     /* Check the priority list.
@@ -681,6 +682,10 @@ static int tgt_get_match(buf_t *buf)
             goto found_one;
         }
     }
+
+#ifdef WITH_UNORDERED_MATCHING
+  not_found:
+#endif
 
     /* Failed to match any elements */
     if (pt->options & PTL_PT_FLOWCTRL) {


### PR DESCRIPTION
Unordered matching was not handling the case when a matching operation was performed and the ME was not found in the matchlist hash table. 