### PR TITLE
Use linux/types.h for byte order types

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -200,7 +200,7 @@ AC_CHECK_HEADERS([sys/posix_shm.h], [], [],
 ])
 AC_CHECK_HEADERS([arpa/inet.h limits.h netinet/in.h stddef.h \
         stdint.h stdlib.h string.h sys/file.h sys/socket.h \
-        unistd.h syscall.h])
+        unistd.h syscall.h linux/types.h])
 
 AM_PATH_XML2([2.6.0], [have_libxml=1], [have_libxml=0])
 AM_CONDITIONAL([HAVE_LIBXML], [test "$have_libxml" = "1"])

--- a/src/ib/ptl_byteorder.h
+++ b/src/ib/ptl_byteorder.h
@@ -1,6 +1,9 @@
 #ifndef PTL_BYTEORDER_H
 #define PTL_BYTEORDER_H
 
+#ifdef HAVE_LINUX_TYPES_H
+#include <linux/types.h>
+#else
 /* use these for network byte order */
 typedef uint16_t __be16;
 typedef uint32_t __be32;
@@ -8,6 +11,7 @@ typedef uint64_t __be64;
 typedef uint16_t __le16;
 typedef uint32_t __le32;
 typedef uint64_t __le64;
+#endif
 
 static inline __be16 cpu_to_be16(uint16_t x)
 {


### PR DESCRIPTION
Fix the following build error by using `linux/types.h` when available:
```
$ make
Making all in doc
make[1]: Entering directory `/home/dinanjam/projects/portals4/doc'
make[1]: Nothing to be done for `all'.
make[1]: Leaving directory `/home/dinanjam/projects/portals4/doc'
Making all in include
make[1]: Entering directory `/home/dinanjam/projects/portals4/include'
make  all-am
make[2]: Entering directory `/home/dinanjam/projects/portals4/include'
make[2]: Leaving directory `/home/dinanjam/projects/portals4/include'
make[1]: Leaving directory `/home/dinanjam/projects/portals4/include'
Making all in src
make[1]: Entering directory `/home/dinanjam/projects/portals4/src'
Making all in ib
make[2]: Entering directory `/home/dinanjam/projects/portals4/src/ib'
  CC       libportals_ib_la-ptl_atomic.lo
In file included from ptl_loc.h:53:0,
                 from ptl_atomic.c:7:
ptl_byteorder.h:7:18: error: conflicting types for '__be64'
 typedef uint64_t __be64;
                  ^
In file included from /usr/include/infiniband/verbs.h:44:0,
                 from /usr/include/rdma/rdma_cma.h:39,
                 from ptl_loc.h:47,
                 from ptl_atomic.c:7:
/usr/include/linux/types.h:32:25: note: previous declaration of '__be64' was here
 typedef __u64 __bitwise __be64;
                         ^
In file included from ptl_loc.h:53:0,
                 from ptl_atomic.c:7:
ptl_byteorder.h:10:18: error: conflicting types for '__le64'
 typedef uint64_t __le64;
                  ^
In file included from /usr/include/infiniband/verbs.h:44:0,
                 from /usr/include/rdma/rdma_cma.h:39,
                 from ptl_loc.h:47,
                 from ptl_atomic.c:7:
/usr/include/linux/types.h:31:25: note: previous declaration of '__le64' was here
 typedef __u64 __bitwise __le64;
                         ^
make[2]: *** [libportals_ib_la-ptl_atomic.lo] Error 1
make[2]: Leaving directory `/home/dinanjam/projects/portals4/src/ib'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/home/dinanjam/projects/portals4/src'
make: *** [all-recursive] Error 1
```