### PR TITLE
Fix PPE related compile and link errors.

### DIFF
--- a/src/ib/Makefile.am
+++ b/src/ib/Makefile.am
@@ -97,9 +97,9 @@ endif
 else
 # PPE - (implies no SHMEM; IB optional)
 
-libportals_ib_la_CPPFLAGS = -DIS_LIGHT_LIB -I$(top_srcdir)/include $(XPMEM_CPPFLAGS)
-libportals_ib_la_LIBADD = $(XPMEM_LIBS)
-libportals_ib_la_LDFLAGS = $(XPMEM_LDFLAGS)
+libportals_ib_la_CPPFLAGS = -DIS_LIGHT_LIB -I$(top_srcdir)/include $(ev_CPPFLAGS) $(XPMEM_CPPFLAGS)
+libportals_ib_la_LIBADD = $(ev_LIBS) $(XPMEM_LIBS)
+libportals_ib_la_LDFLAGS = $(ev_LDFLAGS) $(XPMEM_LDFLAGS)
 libportals_ib_la_SOURCES = \
 	ptl_ct_common.c \
 	ptl_ct_common.h \
@@ -205,7 +205,9 @@ endif
 if WITH_TRANSPORT_UDP
 libportals_ppe_la_SOURCES += \
 	ptl_iface_udp.c \
-	ptl_udp.c
+	ptl_udp.c \
+    ptl_rudp.h \
+    ptl_rudp.c
 endif
 
 endif

--- a/src/ib/ptl_mr.c
+++ b/src/ib/ptl_mr.c
@@ -335,6 +335,7 @@ int mr_lookup(ni_t *ni, struct ni_mr_tree *tree, void *start,
 
     mr = NULL;
 
+#if !IS_PPE
     if (global_umn_init == 1){
 
         while (link) {
@@ -407,8 +408,10 @@ int mr_lookup(ni_t *ni, struct ni_mr_tree *tree, void *start,
             mr = NULL;
         }
     }
+    else
+#endif
     /* No memory registration cache enabled */
-    else {
+    {
         INIT_LIST_HEAD(&mr_list);
     }
     /* Insert the new node */


### PR DESCRIPTION
The ummunotify fixes in e053df696250b405f73e37cea5863657d6b1a2b8 introduced a compile error when PPE is enabled.  This PR disables that code when PPE is enabled.  This PR also adds the missing reliable UDP libs to the link line when PPE is enabled.
