### PR TITLE
Protect portals4.h from C++ name mangling with 'extern "C"'.

### DIFF
--- a/include/portals4.h
+++ b/include/portals4.h
@@ -10,6 +10,10 @@
 
 #include <stdint.h> /* assume C99, for uint64_t */
 
+#if defined(c_plusplus) || defined(__cplusplus)
+extern "C" {
+#endif
+
 /*****************
 * Return Values *
 *****************/
@@ -3429,5 +3433,10 @@ int PtlEndBundle(ptl_handle_ni_t ni_handle);
 int PtlHandleIsEqual(ptl_handle_any_t handle1,
                      ptl_handle_any_t handle2);
 /*! @} */
+
+#if defined(c_plusplus) || defined(__cplusplus)
+}
+#endif
+
 #endif /* ifndef PORTALS4_H */
 /* vim:set expandtab: */


### PR DESCRIPTION

Closes #86 
